### PR TITLE
Switching hands automatically unwields

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -24,8 +24,8 @@
 	. = ..()
 	if(!.)
 		var/obj/item/held_item = get_active_held_item()
-		to_chat(usr, span_warning("Your other hand is too busy holding [held_item]."))
-		return
+		var/datum/component/two_handed/th = held_item.GetComponent(/datum/component/two_handed)
+		th.unwield(src)
 
 	if(!held_index)
 		held_index = (active_hand_index % held_items.len)+1

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1054,7 +1054,6 @@
 /mob/proc/swap_hand()
 	var/obj/item/held_item = get_active_held_item()
 	if(SEND_SIGNAL(src, COMSIG_MOB_SWAPPING_HANDS, held_item) & COMPONENT_BLOCK_SWAP)
-		to_chat(src, span_warning("Your other hand is too busy holding [held_item]."))
 		return FALSE
 	SEND_SIGNAL(src, COMSIG_MOB_SWAP_HANDS)
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Upon switching hands, instead of not being allowed to, it will automatically unwield your wielded item and then allow you to switch to your other hand as per usual

## Why It's Good For The Game

Why was this a thing in the first place?

## Changelog

:cl:
add: Automatic unweild on hand switch
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
